### PR TITLE
Add Command method to Browser interface

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,3 +1,0 @@
-// Package webbrowser provides a simple API for opening web pages on your
-// default browser.
-package webbrowser


### PR DESCRIPTION
Apparently xdg-open does wait until the browser process is closed to return.
This is not ideal, `webbrowser.Open` should return inmediately.

See #4 for details.

You might want to take a look and/or locally test this @pquerna